### PR TITLE
ui/prettier-config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,12 +26,6 @@ module.exports = {
     'max-len': ['error', { code: 120, tabWidth: 2 }],
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'prettier/prettier': [
-      'error',
-      {
-        'endOfLine': 'auto',
-      }
-    ]
   },
 
   overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,12 @@ module.exports = {
     'max-len': ['error', { code: 120, tabWidth: 2 }],
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        'endOfLine': 'auto',
+      }
+    ]
   },
 
   overrides: [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,4 +4,5 @@ module.exports = {
   printWidth: 120,
   semi: false,
   singleQuote: true,
+  endOfLine: 'auto',
 }


### PR DESCRIPTION
## Summary of issue

Prettier shows warnings on any new line. It complicates code readability.

## Summary of change

Changed prettier config to understand all newline characters (CR, LF, CRLF)